### PR TITLE
feat: symlink-based repo sync with junctions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,26 +3,6 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
-name = "cicd-workflow"
-version = "0.2.0"
-source = { editable = "." }
-dependencies = [
-    { name = "pyyaml" },
-]
-
-[package.optional-dependencies]
-monitor = [
-    { name = "websockets" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "websockets", marker = "extra == 'monitor'", specifier = ">=12.0" },
-]
-provides-extras = ["monitor"]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -135,3 +115,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
+
+[[package]]
+name = "workflows-manager"
+version = "0.2.5"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+monitor = [
+    { name = "websockets" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "websockets", marker = "extra == 'monitor'", specifier = ">=12.0" },
+]
+provides-extras = ["monitor"]

--- a/wfm/cli.py
+++ b/wfm/cli.py
@@ -1,13 +1,15 @@
-"""CLI for cicd-workflow.
+"""CLI for wfm - Workflow Manager for Claude Code.
 
 Commands:
-    cicd init       Initialize workflows and global skills
-    cicd update     Update global skills and core workflows
-    cicd sync       Force re-download global skills
-    cicd list       List all workflows, agents, and skills
-    cicd status     Show extended workflows and skills info
-    cicd version    Show installed and latest version
-    cicd monitor    Real-time workflow visualization dashboard
+    wfm repo add    Add and clone a repository
+    wfm repo remove Remove a repository
+    wfm repo list   List configured repositories
+    wfm repo pull   Pull updates for all repositories
+    wfm sync        Recreate symlinks for all repos
+    wfm list        List all workflows and skills
+    wfm status      Show status and configuration
+    wfm version     Show installed version
+    wfm self-update Update wfm CLI
 """
 
 import argparse
@@ -18,58 +20,33 @@ from wfm import __version__, workflow_manager
 
 
 def main():
-    """Main entry point for cicd CLI."""
+    """Main entry point for wfm CLI."""
     parser = argparse.ArgumentParser(
-        prog="cicd",
-        description="CI/CD workflows and agents for Claude Code projects"
+        prog="wfm",
+        description="Workflow Manager for Claude Code - manage skills and workflows via git repos"
     )
-    parser.add_argument("-V", "--version", action="version", version=f"cicd-workflow {__version__}")
+    parser.add_argument("-V", "--version", action="version", version=f"wfm {__version__}")
 
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    # init command
-    init_parser = subparsers.add_parser("init", help="Initialize workflows in project")
-    init_parser.add_argument("--force", "-f", action="store_true", help="Reinitialize even if exists")
-    init_parser.add_argument("--version", "-v", dest="release_version", help="Specific version (e.g., v0.1.0)")
-
-    # update command
-    update_parser = subparsers.add_parser("update", help="Update global skills and core workflows")
-    update_parser.add_argument("--version", "-v", dest="release_version", help="Specific version (e.g., v0.1.0)")
-
-    # sync command (v2.0)
-    sync_parser = subparsers.add_parser("sync", help="Force re-download global skills")
-    sync_parser.add_argument("--version", "-v", dest="release_version", help="Specific version (e.g., v0.1.0)")
-    sync_parser.add_argument("--branch", "-b", help="Download from branch instead of release (e.g., feature/6-global-skills-architecture)")
-
-    # migrate command (v2.0)
-    migrate_parser = subparsers.add_parser("migrate", help="Migrate from old commands to global skills")
-    migrate_parser.add_argument("--remove", "-r", action="store_true", help="Remove legacy command files after migration")
+    # sync command (recreate symlinks)
+    subparsers.add_parser("sync", help="Sync all repos (clone if missing, recreate symlinks)")
 
     # list command
-    subparsers.add_parser("list", help="List all workflows, agents, and skills")
+    subparsers.add_parser("list", help="List all workflows and skills")
 
     # status command
-    subparsers.add_parser("status", help="Show extended workflows")
+    subparsers.add_parser("status", help="Show status and configuration")
 
-    # version command (show installed vs latest)
-    subparsers.add_parser("version", help="Show installed and latest version")
-
-    # monitor command
-    monitor_parser = subparsers.add_parser("monitor", help="Real-time workflow visualization")
-    monitor_parser.add_argument("--serve", "-s", action="store_true", help="Start the monitor server")
-    monitor_parser.add_argument("--open", "-o", action="store_true", help="Open dashboard in browser")
-    monitor_parser.add_argument("--emit", "-e", action="store_true", help="Emit an event")
-    monitor_parser.add_argument("--agent", "-a", help="Agent name (for --emit)")
-    monitor_parser.add_argument("--action", help="Action: start, end, error (for --emit)")
-    monitor_parser.add_argument("--workflow", "-w", help="Workflow name (for --emit)")
-    monitor_parser.add_argument("--port", "-p", type=int, default=8000, help="Server port (default: 8000)")
+    # version command
+    subparsers.add_parser("version", help="Show wfm version")
 
     # repo command (multi-repo support)
     repo_parser = subparsers.add_parser("repo", help="Manage workflow repositories")
     repo_subparsers = repo_parser.add_subparsers(dest="repo_command", help="Repository commands")
 
     # repo add
-    repo_add_parser = repo_subparsers.add_parser("add", help="Add a repository")
+    repo_add_parser = repo_subparsers.add_parser("add", help="Add and clone a repository")
     repo_add_parser.add_argument("name", help="Short name for the repo (used as skill prefix)")
     repo_add_parser.add_argument("repo", help="GitHub repo path (e.g., owner/repo)")
 
@@ -80,6 +57,9 @@ def main():
     # repo list
     repo_subparsers.add_parser("list", help="List configured repositories")
 
+    # repo pull
+    repo_subparsers.add_parser("pull", help="Git pull all repositories")
+
     # self-update command
     subparsers.add_parser("self-update", help="Update wfm CLI to the latest release")
 
@@ -89,22 +69,14 @@ def main():
         print_help()
         return 0
 
-    if args.command == "init":
-        return cmd_init(args)
-    elif args.command == "update":
-        return cmd_update(args)
-    elif args.command == "sync":
+    if args.command == "sync":
         return cmd_sync(args)
-    elif args.command == "migrate":
-        return cmd_migrate(args)
     elif args.command == "list":
         return cmd_list()
     elif args.command == "status":
         return cmd_status()
     elif args.command == "version":
         return cmd_version()
-    elif args.command == "monitor":
-        return cmd_monitor(args)
     elif args.command == "repo":
         if args.repo_command == "add":
             return cmd_repo_add(args)
@@ -112,8 +84,10 @@ def main():
             return cmd_repo_remove(args)
         elif args.repo_command == "list":
             return cmd_repo_list()
+        elif args.repo_command == "pull":
+            return cmd_repo_pull()
         else:
-            print("Usage: wfm repo <add|remove|list>")
+            print("Usage: wfm repo <add|remove|list|pull>")
             return 1
     elif args.command == "self-update":
         return cmd_self_update()
@@ -126,268 +100,271 @@ def print_help():
     """Print help message."""
     print("wfm - Workflow Manager for Claude Code")
     print()
+    print("Manage skills and workflows via git repositories with symlinks.")
+    print("You manage git (pull, push, commit), wfm manages the symlinks.")
+    print()
     print("Commands:")
-    print("  wfm init        Initialize global skills and project workflows")
-    print("  wfm update      Update global skills and core workflows")
-    print("  wfm sync        Sync all configured repositories")
-    print("  wfm migrate     Migrate from old commands to global skills")
-    print("  wfm list        List all workflows, agents, and skills")
-    print("  wfm status      Show extended workflows and skills info")
-    print("  wfm version     Show installed and latest version")
-    print("  wfm self-update Update wfm CLI to latest release")
-    print("  wfm repo        Manage workflow repositories")
-    print("  wfm monitor     Real-time workflow visualization")
+    print("  wfm repo add <name> <repo>  Add and clone a repository")
+    print("  wfm repo remove <name>      Remove repository and symlinks")
+    print("  wfm repo list               List configured repositories")
+    print("  wfm repo pull               Git pull all repositories")
+    print("  wfm sync                    Recreate all symlinks")
+    print("  wfm list                    List all skills and workflows")
+    print("  wfm status                  Show configuration and status")
+    print("  wfm version                 Show wfm version")
+    print("  wfm self-update             Update wfm CLI")
     print()
-    print("Repository commands:")
-    print("  wfm repo add <name> <owner/repo>  Add a repository")
-    print("  wfm repo remove <name>            Remove a repository")
-    print("  wfm repo list                     List configured repositories")
-    print()
-    print("Options (init/update/sync):")
-    print("  --force, -f     Reinitialize even if exists (init only)")
-    print("  --version, -v   Install specific version (e.g., -v v0.1.0)")
-    print()
-    print("Migration options:")
-    print("  --remove, -r    Remove legacy command files after migration")
-    print()
-    print("Monitor options:")
-    print("  --serve, -s     Start the monitor server")
-    print("  --open, -o      Open dashboard in browser")
-    print("  --emit, -e      Emit an event to the server")
-    print("  --agent, -a     Agent name (architect, coder, etc.)")
-    print("  --action        Action type (start, end, error)")
-    print("  --workflow, -w  Workflow name")
+    print("Quick start:")
+    print("  wfm repo add cicd dgx80/cicd-workflow")
+    print("  wfm sync")
     print()
     print("Architecture:")
-    print("  ~/.claude/wfm.json   Repository configuration")
-    print("  ~/.claude/skills/    Global skills ({repo}-*)")
-    print("  ~/.claude/workflows/ Global workflows")
-    print("  .claude/rules/       Project context (auto-loaded)")
-    print("  .cicd/extends/       Project extensions (priority)")
-    print()
-    print(f"Default source: {workflow_manager.CICD_WORKFLOW_URL}")
-
-
-def cmd_init(args):
-    """Handle init command."""
-    result = workflow_manager.init(
-        force=args.force,
-        version=getattr(args, 'release_version', None)
-    )
-    print_result(result)
-    return 0 if result["status"] in ("success", "already_initialized") else 1
-
-
-def cmd_update(args):
-    """Handle update command."""
-    result = workflow_manager.update(
-        version=getattr(args, 'release_version', None)
-    )
-    print_result(result)
-    return 0 if result["status"] in ("success", "up_to_date") else 1
+    print("  ~/.claude/wfm.json     Config (repos, ignored skills)")
+    print("  ~/.claude/repos/       Cloned git repositories")
+    print("  ~/.claude/skills/      Symlinks to repos/*/skills/*")
+    print("  ~/.claude/workflows/   Symlinks to repos/*/workflows/*")
 
 
 def cmd_sync(args):
-    """Handle sync command - sync all configured repositories."""
-    branch = getattr(args, 'branch', None)
-    version = getattr(args, 'release_version', None)
+    """Handle sync command - sync all configured repositories via git clone + symlinks."""
+    # Sync all repos (git clone + create symlinks)
+    result = workflow_manager.sync_all()
 
-    if branch:
-        print(f"Syncing from branch: {branch}")
+    if result["status"] == "error":
+        print(f"[ERROR] {result.get('message', 'Unknown error')}")
+        return 1
 
-    # Use sync_all for multi-repo support
-    result = workflow_manager.sync_all(version=version, branch=branch)
-
+    # Print sync results
     if result["status"] == "success":
         print(f"[OK] {result['message']}")
-        for repo_result in result.get("results", []):
-            skills = repo_result.get("skills_synced", [])
-            if skills:
-                print(f"  {repo_result['repo_name']}: {', '.join(skills)}")
-        print(f"\nLocation: {workflow_manager.get_global_skills_path()}")
-        return 0
     elif result["status"] == "partial":
         print(f"[WARN] {result['message']}")
         for error in result.get("errors", []):
             print(f"  - {error}")
-        return 1
-    else:
-        print(f"[ERROR] {result.get('message', 'Unknown error')}")
-        return 1
 
+    # Show synced repos
+    for repo_result in result.get("results", []):
+        if repo_result["status"] == "success":
+            skills = repo_result.get("skills_synced", [])
+            workflows = repo_result.get("workflows_synced", [])
+            print(f"\n  {repo_result['repo_name']}:")
+            if skills:
+                print(f"    Skills: {', '.join(skills)}")
+            if workflows:
+                print(f"    Workflows: {', '.join(workflows)}")
+            print(f"    Path: {repo_result.get('repo_path', 'N/A')}")
 
-def cmd_migrate(args):
-    """Handle migrate command - migrate from old commands to global skills."""
-    # First check if migration is needed
-    detection = workflow_manager.detect_migration_needed()
+    # Handle orphan skills
+    orphan_skills = result.get("orphan_skills", [])
+    if orphan_skills:
+        print(f"\n[INFO] Detected {len(orphan_skills)} orphan skill(s) (not linked to any repo):")
+        repos = list(workflow_manager.get_configured_repos().keys())
 
-    if not detection["needs_migration"]:
-        if detection["has_global_skills"]:
-            print("[INFO] Global skills already installed. Use 'cicd sync' to update.")
-        else:
-            print("[INFO] No legacy commands found. Nothing to migrate.")
-        return 0
+        for skill in orphan_skills:
+            print(f"\n  Skill: {skill}")
+            print(f"  Where to place this skill?")
+            for i, repo in enumerate(repos):
+                print(f"    {i + 1}. {repo}")
+            print(f"    0. Ignore (don't ask again)")
+            print(f"    Enter. Skip for now")
 
-    print("Migration detected:")
-    print(f"  Legacy commands: {detection['has_legacy_commands']}")
-    print(f"  Global skills: {detection['has_global_skills']}")
-    print()
+            try:
+                choice = input("  > ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\n  Skipped.")
+                continue
 
-    # Perform migration
-    result = workflow_manager.migrate(remove_legacy=args.remove)
-    print_result(result)
+            if choice == "0":
+                workflow_manager.ignore_skill(skill)
+                print(f"  [OK] '{skill}' added to ignored list")
+            elif choice.isdigit() and 0 < int(choice) <= len(repos):
+                repo_name = repos[int(choice) - 1]
+                adopt_result = workflow_manager.adopt_skill(skill, repo_name)
+                if adopt_result["status"] == "success":
+                    print(f"  [OK] {adopt_result['message']}")
+                else:
+                    print(f"  [ERROR] {adopt_result['message']}")
+            else:
+                print(f"  Skipped.")
 
-    if result["status"] == "success":
-        skills = result.get("migrated_skills", [])
-        if skills:
-            print(f"\nMigrated skills: {', '.join(skills)}")
-            print(f"Location: {result.get('global_skills_path')}")
-            if result.get("rules_created"):
-                print(f"Rules template: {result.get('rules_created')}")
-            if result.get("removed_files"):
-                print(f"Removed legacy files: {', '.join(result['removed_files'])}")
+    # Handle orphan workflows
+    orphan_workflows = result.get("orphan_workflows", [])
+    if orphan_workflows:
+        print(f"\n[INFO] Detected {len(orphan_workflows)} orphan workflow(s):")
+        repos = list(workflow_manager.get_configured_repos().keys())
 
-    return 0 if result["status"] in ("success", "not_needed", "already_migrated") else 1
+        for wf in orphan_workflows:
+            print(f"\n  Workflow: {wf}")
+            print(f"  Where to place this workflow?")
+            for i, repo in enumerate(repos):
+                print(f"    {i + 1}. {repo}")
+            print(f"    0. Ignore (don't ask again)")
+            print(f"    Enter. Skip for now")
+
+            try:
+                choice = input("  > ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\n  Skipped.")
+                continue
+
+            if choice == "0":
+                workflow_manager.ignore_workflow(wf)
+                print(f"  [OK] '{wf}' added to ignored list")
+            elif choice.isdigit() and 0 < int(choice) <= len(repos):
+                repo_name = repos[int(choice) - 1]
+                adopt_result = workflow_manager.adopt_workflow(wf, repo_name)
+                if adopt_result["status"] == "success":
+                    print(f"  [OK] {adopt_result['message']}")
+                else:
+                    print(f"  [ERROR] {adopt_result['message']}")
+            else:
+                print(f"  Skipped.")
+
+    print(f"\nRepos: {workflow_manager.get_repos_path()}")
+    print(f"Skills: {workflow_manager.get_global_skills_path()}")
+    print(f"Workflows: {workflow_manager.get_global_workflows_path()}")
+
+    return 0 if result["status"] == "success" else 1
 
 
 def cmd_list():
-    """Handle list command."""
-    result = workflow_manager.list_workflows()
+    """Handle list command - list all skills and workflows."""
+    from wfm import platform as plat
 
-    # Show version info
-    global_version = workflow_manager.get_global_installed_version()
-    local_version = result.get("version")
+    repos = workflow_manager.get_configured_repos()
 
-    if global_version:
-        print(f"Global version: {global_version}")
-    if local_version and local_version != global_version:
-        print(f"Project version: {local_version}")
-    if not global_version and not local_version:
-        print("[WARN] Not initialized. Run 'wfm init'")
+    if not repos:
+        print("No repositories configured.")
+        print("Use 'wfm repo add <name> <owner/repo>' to add one.")
+        return 0
+
+    print("Configured Repositories:")
+    for name, repo in repos.items():
+        repo_path = workflow_manager.get_repos_path() / name
+        status = "cloned" if repo_path.exists() else "not cloned"
+        print(f"  {name}: {repo} ({status})")
     print()
 
-    # Show configured repos
-    repos = workflow_manager.get_configured_repos()
-    if repos:
-        print("Configured Repositories:")
-        for name, repo in repos.items():
-            print(f"  {name}: {repo}")
-        print()
+    # List skills
+    skills_path = workflow_manager.get_global_skills_path()
+    if skills_path.exists():
+        skills = []
+        for item in sorted(skills_path.iterdir()):
+            if item.is_dir() and (item / "SKILL.md").exists():
+                is_link = plat.is_link(item)
+                link_marker = "" if is_link else " (orphan)"
+                skills.append(f"  /{item.name}{link_marker}")
 
-    # List global skills with repo source
-    skills = workflow_manager.list_global_skills_with_repo()
-    if skills:
-        print("Global Skills (~/.claude/skills/):")
-        for skill_name in sorted(skills.keys()):
-            info = skills[skill_name]
-            repo = info.get("repo", "unknown")
-            print(f"  [{repo:8}] /{skill_name}")
+        if skills:
+            print(f"Skills ({len(skills)}):")
+            for s in skills:
+                print(s)
+        else:
+            print("No skills installed.")
     else:
-        print("No global skills installed.")
+        print("No skills installed.")
     print()
 
     # List workflows
-    workflows = result.get("workflows", {})
-    if workflows:
-        print("Workflows (.cicd/core/):")
-        for name, info in sorted(workflows.items()):
-            source = info["source"]
-            marker = " (override)" if info.get("overridden") else ""
-            print(f"  [{source:7}] {name}{marker}")
-    else:
-        print("No workflows found.")
+    workflows_path = workflow_manager.get_global_workflows_path()
+    if workflows_path.exists():
+        workflows = []
+        for item in sorted(workflows_path.iterdir()):
+            if item.is_dir() and (item / "workflow.md").exists():
+                is_link = plat.is_link(item)
+                link_marker = "" if is_link else " (orphan)"
+                workflows.append(f"  {item.name}{link_marker}")
 
-    print()
-
-    # List agents
-    agents = result.get("agents", {})
-    if agents:
-        print("Agents:")
-        for name, info in sorted(agents.items()):
-            source = info["source"]
-            marker = " (override)" if info.get("overridden") else ""
-            print(f"  [{source:7}] {name}{marker}")
+        if workflows:
+            print(f"Workflows ({len(workflows)}):")
+            for w in workflows:
+                print(w)
+        else:
+            print("No workflows installed.")
     else:
-        print("No agents found.")
+        print("No workflows installed.")
 
     return 0
 
 
 def cmd_status():
-    """Handle status command."""
-    result = workflow_manager.status()
-
-    # Show version info (v2.0)
-    global_version = workflow_manager.get_global_installed_version()
-    local_version = result.get("version")
-
-    if not global_version and not result.get("initialized"):
-        print("[WARN] Not initialized. Run 'wfm init'")
-        return 1
+    """Handle status command - show configuration and paths."""
+    from wfm import platform as plat
+    import subprocess
 
     print("=== WFM Status ===")
     print()
 
-    # Show configured repos
+    # Paths
+    print("Paths:")
+    print(f"  Config:    {workflow_manager.get_wfm_config_path()}")
+    print(f"  Repos:     {workflow_manager.get_repos_path()}")
+    print(f"  Skills:    {workflow_manager.get_global_skills_path()}")
+    print(f"  Workflows: {workflow_manager.get_global_workflows_path()}")
+    print()
+
+    # Repos with git status
     repos = workflow_manager.get_configured_repos()
-    print(f"Configured Repositories: {len(repos)}")
-    for name, repo in repos.items():
-        print(f"  {name}: {repo}")
+    if repos:
+        print(f"Repositories ({len(repos)}):")
+        for name, repo in repos.items():
+            repo_path = workflow_manager.get_repos_path() / name
+            if repo_path.exists():
+                # Get git status
+                try:
+                    result = subprocess.run(
+                        ["git", "status", "--porcelain"],
+                        cwd=str(repo_path),
+                        capture_output=True,
+                        text=True,
+                        timeout=5
+                    )
+                    changes = len(result.stdout.strip().split("\n")) if result.stdout.strip() else 0
+                    status = f"{changes} changes" if changes > 0 else "clean"
+                except Exception:
+                    status = "unknown"
+                print(f"  {name}: {repo} [{status}]")
+            else:
+                print(f"  {name}: {repo} [not cloned]")
+    else:
+        print("No repositories configured.")
     print()
 
-    # Global skills info by repo
-    skills_by_repo = workflow_manager.list_global_skills_with_repo()
-    skills = workflow_manager.list_global_skills()
+    # Count skills and workflows
+    skills_path = workflow_manager.get_global_skills_path()
+    workflows_path = workflow_manager.get_global_workflows_path()
 
-    # Count skills per repo
-    repo_counts = {}
-    for skill_name, info in skills_by_repo.items():
-        repo = info.get("repo", "unknown")
-        repo_counts[repo] = repo_counts.get(repo, 0) + 1
+    skill_count = 0
+    orphan_skills = 0
+    if skills_path.exists():
+        for item in skills_path.iterdir():
+            if item.is_dir() and (item / "SKILL.md").exists():
+                skill_count += 1
+                if not plat.is_link(item):
+                    orphan_skills += 1
 
-    print(f"Global Skills: {len(skills)} installed")
-    for repo_name, count in sorted(repo_counts.items()):
-        print(f"  {repo_name}: {count} skills")
+    workflow_count = 0
+    orphan_workflows = 0
+    if workflows_path.exists():
+        for item in workflows_path.iterdir():
+            if item.is_dir() and (item / "workflow.md").exists():
+                workflow_count += 1
+                if not plat.is_link(item):
+                    orphan_workflows += 1
 
-    if global_version:
-        print(f"Global Version: {global_version}")
-    print(f"Skills Path: {workflow_manager.get_global_skills_path()}")
-    print()
+    print(f"Skills: {skill_count} total, {orphan_skills} orphans")
+    print(f"Workflows: {workflow_count} total, {orphan_workflows} orphans")
 
-    # Project info
-    if result.get("initialized"):
-        print(f"Project Version: {local_version or 'unknown'}")
-
-        overridden_wf = result.get("overridden_workflows", {})
-        overridden_ag = result.get("overridden_agents", {})
-        total_wf = result.get("total_workflows", 0)
-        total_ag = result.get("total_agents", 0)
-
-        print(f"Workflows: {len(overridden_wf)} extended / {total_wf} total")
-        print(f"Agents:    {len(overridden_ag)} extended / {total_ag} total")
-
-        if overridden_wf:
-            print()
-            print("Extended workflows:")
-            for name in sorted(overridden_wf.keys()):
-                print(f"  - {name}")
-
-        if overridden_ag:
-            print()
-            print("Extended agents:")
-            for name in sorted(overridden_ag.keys()):
-                print(f"  - {name}")
-    else:
-        print("Project: not initialized (global skills only)")
-
-    # Check for project rules
-    rules_path = workflow_manager.get_project_cicd_path().parent / ".claude" / "rules" / "cicd-context.md"
-    if rules_path.exists():
+    # Show ignored items
+    ignored_skills = workflow_manager.get_ignored_skills()
+    ignored_workflows = workflow_manager.get_ignored_workflows()
+    if ignored_skills or ignored_workflows:
         print()
-        print(f"Project Rules: {rules_path}")
-    else:
-        print()
-        print("Project Rules: not configured (run 'wfm init' to create template)")
+        print("Ignored:")
+        if ignored_skills:
+            print(f"  Skills: {', '.join(ignored_skills)}")
+        if ignored_workflows:
+            print(f"  Workflows: {', '.join(ignored_workflows)}")
 
     return 0
 
@@ -397,8 +374,7 @@ def cmd_version():
     import subprocess
     import json
 
-    # WFM CLI version
-    print(f"wfm CLI:       {__version__}")
+    print(f"wfm: {__version__}")
 
     # Get latest wfm release from GitHub
     try:
@@ -411,27 +387,11 @@ def cmd_version():
         if result.returncode == 0:
             data = json.loads(result.stdout)
             latest_wfm = data.get("tagName", "").lstrip("v")
-            print(f"wfm Latest:    {latest_wfm}")
             if __version__ != latest_wfm:
-                print()
-                print("Update available! Run 'wfm self-update'")
-        else:
-            print(f"wfm Latest:    unknown")
+                print(f"Update available: {latest_wfm}")
+                print("Run 'wfm self-update' to update.")
     except Exception:
-        print(f"wfm Latest:    unknown")
-
-    print()
-
-    # Workflow skills version
-    global_version = workflow_manager.get_global_installed_version()
-    latest_skills = workflow_manager.get_latest_version()
-
-    print(f"Skills:        {global_version or 'not installed'}")
-    print(f"Skills Latest: {latest_skills or 'unknown'}")
-
-    if global_version and latest_skills and global_version != latest_skills:
-        print()
-        print("Skills update available! Run 'wfm update'")
+        pass
 
     return 0
 
@@ -518,22 +478,46 @@ def cmd_self_update():
 
 
 def cmd_repo_add(args):
-    """Handle repo add command."""
+    """Handle repo add command - adds repo to config and clones it."""
+    # Add to config
     result = workflow_manager.add_repo(args.name, args.repo)
-    if result["status"] == "success":
-        print(f"[OK] {result['message']}")
-        print(f"Run 'wfm sync' to download skills from this repository.")
+    if result["status"] != "success":
+        print(f"[ERROR] {result['message']}")
+        return 1
+
+    print(f"[OK] {result['message']}")
+
+    # Clone and create symlinks
+    print(f"Cloning {args.repo}...")
+    sync_result = workflow_manager.sync_repo(args.name, args.repo)
+
+    if sync_result["status"] == "success":
+        skills = sync_result.get("skills_synced", [])
+        workflows = sync_result.get("workflows_synced", [])
+        print(f"[OK] Cloned to {sync_result.get('repo_path')}")
+        if skills:
+            print(f"  Skills: {', '.join(skills)}")
+        if workflows:
+            print(f"  Workflows: {', '.join(workflows)}")
         return 0
     else:
-        print(f"[ERROR] {result['message']}")
+        print(f"[ERROR] {sync_result.get('message', 'Sync failed')}")
         return 1
 
 
 def cmd_repo_remove(args):
-    """Handle repo remove command."""
+    """Handle repo remove command - removes repo, symlinks, and cloned folder."""
     result = workflow_manager.remove_repo(args.name)
     if result["status"] == "success":
         print(f"[OK] {result['message']}")
+        removed_skills = result.get("removed_skills", [])
+        removed_workflows = result.get("removed_workflows", [])
+        if removed_skills:
+            print(f"  Removed skill links: {', '.join(removed_skills)}")
+        if removed_workflows:
+            print(f"  Removed workflow links: {', '.join(removed_workflows)}")
+        if result.get("removed_repo_path"):
+            print(f"  Removed repo: {result['removed_repo_path']}")
         return 0
     else:
         print(f"[ERROR] {result['message']}")
@@ -554,115 +538,58 @@ def cmd_repo_list():
     return 0
 
 
-def cmd_monitor(args):
-    """Handle monitor command."""
-    from wfm import monitor
+def cmd_repo_pull():
+    """Handle repo pull command - git pull all repositories."""
+    import subprocess
 
-    if args.emit:
-        # Emit an event
-        if not args.agent:
-            print("[ERROR] --agent is required for --emit")
-            return 1
-        if not args.action:
-            print("[ERROR] --action is required for --emit")
-            return 1
+    repos = workflow_manager.get_configured_repos()
 
-        # Force enable for CLI emit command
-        os.environ["CICD_MONITOR"] = "1"
-        emitter = monitor.EventEmitter(port=args.port)
-        result = emitter.emit(
-            agent=args.agent,
-            action=args.action,
-            workflow=args.workflow,
-        )
-
-        if result["status"] == "success":
-            print(f"[OK] Event emitted: {args.agent} → {args.action}")
-        elif result["status"] == "offline":
-            print(f"[WARN] {result['message']}")
-        else:
-            print(f"[ERROR] {result.get('message', 'Unknown error')}")
+    if not repos:
+        print("No repositories configured.")
         return 0
 
-    if args.serve:
-        # Start the FastAPI server with uvicorn
-        import shutil
-        import subprocess
-        import sys
-        from pathlib import Path
+    print("Pulling all repositories...")
+    errors = []
 
-        print(f"Starting CICD Monitor server on port {args.port}...")
+    for name, repo in repos.items():
+        repo_path = workflow_manager.get_repos_path() / name
 
-        if args.open:
-            # Open browser after a short delay
-            import threading
-            import time
-            def open_browser():
-                time.sleep(2.0)
-                monitor.open_dashboard(args.port)
-            threading.Thread(target=open_browser, daemon=True).start()
+        if not repo_path.exists():
+            print(f"  {name}: not cloned (run 'wfm sync' first)")
+            continue
 
-        # Find backend directory
-        backend_dir = Path(__file__).parent.parent / "backend"
-        if not backend_dir.exists():
-            print("[ERROR] Backend directory not found. Please install from source.")
-            return 1
-
-        # Run uvicorn (prefer uv if available)
         try:
-            if shutil.which("uv"):
-                subprocess.run(
-                    ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", str(args.port)],
-                    cwd=str(backend_dir),
-                    check=True,
-                )
+            result = subprocess.run(
+                ["git", "pull"],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            if result.returncode == 0:
+                output = result.stdout.strip()
+                if "Already up to date" in output:
+                    print(f"  {name}: up to date")
+                else:
+                    print(f"  {name}: updated")
             else:
-                subprocess.run(
-                    [sys.executable, "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", str(args.port)],
-                    cwd=str(backend_dir),
-                    check=True,
-                )
-        except KeyboardInterrupt:
-            print("\nServer stopped.")
-        except subprocess.CalledProcessError as e:
-            print(f"[ERROR] Server failed: {e}")
-            return 1
-        return 0
+                print(f"  {name}: FAILED - {result.stderr.strip()}")
+                errors.append(name)
 
-    if args.open:
-        # Just open the dashboard
-        print(f"Opening dashboard at http://localhost:{args.port}")
-        monitor.open_dashboard(args.port)
-        return 0
+        except subprocess.TimeoutExpired:
+            print(f"  {name}: FAILED - timeout")
+            errors.append(name)
+        except Exception as e:
+            print(f"  {name}: FAILED - {e}")
+            errors.append(name)
 
-    # Default: show help for monitor
-    print("cicd monitor - Real-time workflow visualization")
-    print()
-    print("Usage:")
-    print("  cicd monitor --serve          Start the monitor server")
-    print("  cicd monitor --serve --open   Start server and open dashboard")
-    print("  cicd monitor --open           Open dashboard in browser")
-    print("  cicd monitor --emit ...       Emit an event")
-    print()
-    print("Emit event example:")
-    print("  cicd monitor --emit --agent architect --action start --workflow design-feature")
+    if errors:
+        print(f"\n[WARN] {len(errors)} repo(s) failed to pull")
+        return 1
+
+    print("\n[OK] All repositories pulled")
     return 0
-
-
-def print_result(result: dict):
-    """Print command result."""
-    status = result.get("status", "unknown")
-
-    if status == "success":
-        print(f"[OK] {result.get('message', 'Success')}")
-    elif status == "up_to_date":
-        print(f"[OK] {result.get('message', 'Up to date')}")
-    elif status == "already_initialized":
-        print(f"[INFO] {result.get('message', 'Already initialized')}")
-    elif status == "not_initialized":
-        print(f"[WARN] {result.get('message', 'Not initialized')}")
-    else:
-        print(f"[ERROR] {result.get('message', 'Unknown error')}")
 
 
 if __name__ == "__main__":

--- a/wfm/platform.py
+++ b/wfm/platform.py
@@ -1,0 +1,168 @@
+"""Cross-platform symlink/junction utilities.
+
+Windows: Uses junctions (no admin privileges required)
+Unix/Mac: Uses symlinks
+"""
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+
+def create_link(source: Path, target: Path) -> bool:
+    """Create a junction (Windows) or symlink (Unix) from target to source.
+
+    Args:
+        source: The existing directory to link to (the repo folder)
+        target: The link path to create (in ~/.claude/skills/ or workflows/)
+
+    Returns:
+        True if successful
+
+    Raises:
+        subprocess.CalledProcessError: If junction creation fails on Windows
+        OSError: If symlink creation fails on Unix
+    """
+    # Ensure source exists
+    if not source.exists():
+        raise FileNotFoundError(f"Source directory does not exist: {source}")
+
+    # Remove existing link/directory if present
+    if target.exists() or is_link(target):
+        remove_link(target)
+
+    # Ensure parent directory exists
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if platform.system() == "Windows":
+        # Junction - no admin privileges required
+        # mklink /J creates a directory junction
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(target), str(source)],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+        return True
+    else:
+        # Unix/Mac - use symlink
+        os.symlink(source, target)
+        return True
+
+
+def remove_link(path: Path) -> bool:
+    """Remove a junction (Windows) or symlink (Unix).
+
+    Args:
+        path: The link path to remove
+
+    Returns:
+        True if successful, False if path doesn't exist
+    """
+    if not path.exists() and not is_link(path):
+        return False
+
+    if platform.system() == "Windows":
+        # rmdir for junction - does NOT delete the target contents
+        if is_link(path):
+            subprocess.run(
+                ["cmd", "/c", "rmdir", str(path)],
+                check=True,
+                capture_output=True
+            )
+        else:
+            # Regular directory - use rmdir /s /q
+            subprocess.run(
+                ["cmd", "/c", "rmdir", "/s", "/q", str(path)],
+                check=True,
+                capture_output=True
+            )
+        return True
+    else:
+        # Unix - unlink for symlink, rmdir for directory
+        if path.is_symlink():
+            os.unlink(path)
+        elif path.is_dir():
+            import shutil
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+        return True
+
+
+def is_link(path: Path) -> bool:
+    """Check if path is a junction (Windows) or symlink (Unix).
+
+    Args:
+        path: Path to check
+
+    Returns:
+        True if path is a junction or symlink
+    """
+    if not path.exists() and not _path_is_reparse_point(path):
+        return False
+
+    if platform.system() == "Windows":
+        return _path_is_reparse_point(path)
+    else:
+        return path.is_symlink()
+
+
+def _path_is_reparse_point(path: Path) -> bool:
+    """Check if path is a Windows reparse point (junction or symlink).
+
+    Uses GetFileAttributesW to check FILE_ATTRIBUTE_REPARSE_POINT (0x400).
+    """
+    if platform.system() != "Windows":
+        return False
+
+    try:
+        import ctypes
+        attrs = ctypes.windll.kernel32.GetFileAttributesW(str(path))
+        if attrs == -1:  # INVALID_FILE_ATTRIBUTES
+            return False
+        # FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+        return bool(attrs & 0x400)
+    except Exception:
+        return False
+
+
+def get_link_target(path: Path) -> Path | None:
+    """Get the target of a junction/symlink.
+
+    Args:
+        path: The link path
+
+    Returns:
+        The target path, or None if not a link
+    """
+    if not is_link(path):
+        return None
+
+    if platform.system() == "Windows":
+        # Use dir command to get junction target
+        try:
+            result = subprocess.run(
+                ["cmd", "/c", "dir", str(path.parent), "/AL"],
+                capture_output=True,
+                text=True
+            )
+            # Parse output to find target
+            for line in result.stdout.split("\n"):
+                if path.name in line and "[" in line:
+                    # Extract target from [target] format
+                    start = line.find("[") + 1
+                    end = line.find("]")
+                    if start > 0 and end > start:
+                        return Path(line[start:end])
+        except Exception:
+            pass
+        return None
+    else:
+        # Unix - use readlink
+        try:
+            return Path(os.readlink(path))
+        except Exception:
+            return None

--- a/wfm/workflow_manager.py
+++ b/wfm/workflow_manager.py
@@ -138,12 +138,11 @@ def add_repo(name: str, repo: str) -> dict:
     }
 
 
-def remove_repo(name: str, remove_skills: bool = False) -> dict:
-    """Remove a repository from the config.
+def remove_repo(name: str) -> dict:
+    """Remove a repository from the config, its symlinks, and the cloned repo.
 
     Args:
         name: Short name of the repo to remove
-        remove_skills: If True, also remove installed skills for this repo
 
     Returns:
         Result dict with status and message
@@ -158,24 +157,27 @@ def remove_repo(name: str, remove_skills: bool = False) -> dict:
 
     removed_repo = config["repos"].pop(name)
 
-    # Optionally remove skills for this repo
-    removed_skills = []
-    if remove_skills:
-        skills_path = get_global_skills_path()
-        if skills_path.exists():
-            for skill_dir in skills_path.glob(f"{name}-*"):
-                if skill_dir.is_dir():
-                    shutil.rmtree(skill_dir)
-                    removed_skills.append(skill_dir.name)
+    # Remove all symlinks for this repo
+    links_result = remove_repo_links(name)
+
+    # Remove the cloned repo directory
+    repos_path = get_repos_path()
+    repo_path = repos_path / name
+    if repo_path.exists():
+        def _on_rm_error(func, path, exc_info):
+            """Handle read-only files (e.g., .git objects on Windows)."""
+            os.chmod(path, 0o777)
+            func(path)
+        shutil.rmtree(repo_path, onexc=_on_rm_error)
 
     if write_wfm_config(config):
-        result = {
+        return {
             "status": "success",
-            "message": f"Removed repository '{name}' ({removed_repo})"
+            "message": f"Removed repository '{name}' ({removed_repo})",
+            "removed_skills": links_result.get("removed_skills", []),
+            "removed_workflows": links_result.get("removed_workflows", []),
+            "removed_repo_path": str(repo_path)
         }
-        if removed_skills:
-            result["removed_skills"] = removed_skills
-        return result
     return {
         "status": "error",
         "message": "Failed to write config"
@@ -225,6 +227,11 @@ def detect_skill_conflicts() -> dict:
 def get_global_claude_path() -> Path:
     """Get the global ~/.claude/ directory path."""
     return Path.home() / ".claude"
+
+
+def get_repos_path() -> Path:
+    """Get the repos directory path (~/.claude/repos/)."""
+    return get_global_claude_path() / "repos"
 
 
 def get_global_skills_path() -> Path:
@@ -926,123 +933,112 @@ def sync(version: str | None = None, branch: str | None = None) -> dict:
     }
 
 
-def sync_repo(name: str, repo: str, version: str | None = None, branch: str | None = None) -> dict:
-    """Sync a single repository.
+def sync_repo(name: str, repo: str) -> dict:
+    """Sync a single repository using git clone + symlinks.
+
+    1. Clone repo to ~/.claude/repos/{name}/ if not present
+    2. Create symlinks for skills and workflows
 
     Args:
         name: Short name for the repo (used as skill prefix)
         repo: GitHub repo path (e.g., "owner/repo")
-        version: Specific version tag
-        branch: Branch to download from (overrides version)
 
     Returns:
         Result dict with status and details
     """
-    # Download from GitHub
-    if branch:
-        download_result = download_branch(branch=branch, repo=repo)
-    else:
-        download_result = download_release(version=version, repo=repo)
+    repos_path = get_repos_path()
+    repo_path = repos_path / name
 
-    if download_result["status"] != "success":
-        return {
-            "status": "error",
-            "repo_name": name,
-            "repo": repo,
-            "message": download_result.get("message", "Download failed")
-        }
+    # 1. Clone if missing
+    if not repo_path.exists() or not (repo_path / ".git").exists():
+        clone_result = clone_repo(name, repo)
+        if clone_result["status"] == "error":
+            return {
+                "status": "error",
+                "repo_name": name,
+                "repo": repo,
+                "message": clone_result.get("message", "Clone failed")
+            }
 
-    source_path = download_result["path"]
-    new_version = download_result["version"]
+    # 2. Create skill links
+    skills_created = create_skill_links(name)
 
-    # Remove existing skills for this repo prefix
-    skills_path = get_global_skills_path()
-    if skills_path.exists():
-        for skill_dir in skills_path.glob(f"{name}-*"):
-            if skill_dir.is_dir():
-                shutil.rmtree(skill_dir)
-
-    # Install skills with repo name as prefix
-    skills_result = install_skills(source_path, new_version, prefix=name)
-
-    # Install workflows and schemas (only from primary repo)
-    # For now, only install core from the first repo
-    core_result = {"workflows_count": 0, "workflows": []}
-
-    # Cleanup temp directory
-    if download_result.get("temp_dir"):
-        shutil.rmtree(download_result["temp_dir"], ignore_errors=True)
+    # 3. Create workflow links
+    workflows_created = create_workflow_links(name)
 
     return {
         "status": "success",
         "repo_name": name,
         "repo": repo,
-        "version": new_version,
-        "skills_synced": skills_result.get("installed", []),
-        "skills_count": skills_result.get("count", 0)
+        "repo_path": str(repo_path),
+        "skills_synced": skills_created,
+        "skills_count": len(skills_created),
+        "workflows_synced": workflows_created,
+        "workflows_count": len(workflows_created)
     }
 
 
-def sync_all(version: str | None = None, branch: str | None = None) -> dict:
+def sync_all() -> dict:
     """Sync all configured repositories from wfm.json.
 
-    Args:
-        version: Specific version (only applies to first repo)
-        branch: Branch to download from (only applies to first repo)
+    1. For each repo: clone if missing, then create symlinks
+    2. Detect orphan skills/workflows (directories not linked)
 
     Returns:
-        Result dict with status and details for each repo
+        Result dict with status, synced repos, and orphans
     """
     repos = get_configured_repos()
 
     if not repos:
-        # No repos configured, fall back to default
-        repos = {"cicd": CICD_WORKFLOW_REPO}
+        return {
+            "status": "error",
+            "message": "No repositories configured. Use 'wfm repo add <name> <owner/repo>' first."
+        }
 
     results = []
     total_skills = 0
+    total_workflows = 0
     errors = []
 
-    for i, (name, repo) in enumerate(repos.items()):
-        # Only use version/branch for the first repo
-        repo_version = version if i == 0 else None
-        repo_branch = branch if i == 0 else None
-
-        result = sync_repo(name, repo, version=repo_version, branch=repo_branch)
+    for name, repo in repos.items():
+        result = sync_repo(name, repo)
         results.append(result)
 
         if result["status"] == "success":
             total_skills += result.get("skills_count", 0)
+            total_workflows += result.get("workflows_count", 0)
         else:
             errors.append(f"{name}: {result.get('message', 'Unknown error')}")
 
-    # Install core (workflows/schemas) from first repo only
-    if repos:
-        first_name, first_repo = next(iter(repos.items()))
-        if branch:
-            download_result = download_branch(branch=branch, repo=first_repo)
-        else:
-            download_result = download_release(version=version, repo=first_repo)
-
-        if download_result["status"] == "success":
-            core_result = install_core(download_result["path"], download_result["version"])
-            if download_result.get("temp_dir"):
-                shutil.rmtree(download_result["temp_dir"], ignore_errors=True)
+    # Detect orphans
+    orphan_skills = detect_orphan_skills()
+    orphan_workflows = detect_orphan_workflows()
+    ignored_skills = get_ignored_skills()
+    ignored_workflows = get_ignored_workflows()
 
     if errors:
         return {
             "status": "partial",
-            "message": f"Synced {total_skills} skills with {len(errors)} error(s)",
+            "message": f"Synced {total_skills} skills, {total_workflows} workflows with {len(errors)} error(s)",
             "results": results,
-            "errors": errors
+            "errors": errors,
+            "orphan_skills": orphan_skills,
+            "orphan_workflows": orphan_workflows,
+            "ignored_skills": ignored_skills,
+            "ignored_workflows": ignored_workflows
         }
 
     return {
         "status": "success",
-        "message": f"Synced {total_skills} skills from {len(repos)} repo(s)",
+        "message": f"Synced {total_skills} skills, {total_workflows} workflows from {len(repos)} repo(s)",
         "results": results,
         "repos_count": len(repos),
-        "total_skills": total_skills
+        "total_skills": total_skills,
+        "total_workflows": total_workflows,
+        "orphan_skills": orphan_skills,
+        "orphan_workflows": orphan_workflows,
+        "ignored_skills": ignored_skills,
+        "ignored_workflows": ignored_workflows
     }
 
 
@@ -1299,3 +1295,399 @@ def needs_config_migration() -> bool:
     old_config_path = get_global_config_path()
     new_config_path = get_wfm_config_path()
     return old_config_path.exists() and not new_config_path.exists()
+
+
+# =============================================================================
+# Symlink-based Repo Sync (v3.0)
+# =============================================================================
+
+def clone_repo(name: str, repo: str) -> dict:
+    """Clone a GitHub repo to ~/.claude/repos/{name}/.
+
+    Args:
+        name: Short name for the repo (e.g., "cicd")
+        repo: GitHub repo path (e.g., "dgx80/cicd-workflow")
+
+    Returns:
+        Result dict with status and path
+    """
+    repos_path = get_repos_path()
+    repo_path = repos_path / name
+
+    # Create repos directory if needed
+    repos_path.mkdir(parents=True, exist_ok=True)
+
+    # Skip if already cloned
+    if repo_path.exists() and (repo_path / ".git").exists():
+        return {
+            "status": "already_exists",
+            "path": repo_path,
+            "message": f"Repository already cloned at {repo_path}"
+        }
+
+    # Clone the repository
+    repo_url = f"https://github.com/{repo}.git"
+
+    try:
+        result = subprocess.run(
+            ["git", "clone", repo_url, str(repo_path)],
+            capture_output=True,
+            text=True,
+            timeout=120
+        )
+
+        if result.returncode != 0:
+            return {
+                "status": "error",
+                "message": f"Git clone failed: {result.stderr}"
+            }
+
+        return {
+            "status": "success",
+            "path": repo_path,
+            "message": f"Cloned {repo} to {repo_path}"
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "error",
+            "message": "Git clone timed out"
+        }
+    except FileNotFoundError:
+        return {
+            "status": "error",
+            "message": "Git not found. Please install Git."
+        }
+
+
+def get_ignored_skills() -> list[str]:
+    """Get list of ignored skills from wfm.json."""
+    config = read_wfm_config()
+    return config.get("ignored_skills", [])
+
+
+def get_ignored_workflows() -> list[str]:
+    """Get list of ignored workflows from wfm.json."""
+    config = read_wfm_config()
+    return config.get("ignored_workflows", [])
+
+
+def ignore_skill(skill_name: str) -> None:
+    """Add a skill to the ignored_skills list in wfm.json."""
+    config = read_wfm_config()
+    if "ignored_skills" not in config:
+        config["ignored_skills"] = []
+    if skill_name not in config["ignored_skills"]:
+        config["ignored_skills"].append(skill_name)
+    write_wfm_config(config)
+
+
+def ignore_workflow(workflow_name: str) -> None:
+    """Add a workflow to the ignored_workflows list in wfm.json."""
+    config = read_wfm_config()
+    if "ignored_workflows" not in config:
+        config["ignored_workflows"] = []
+    if workflow_name not in config["ignored_workflows"]:
+        config["ignored_workflows"].append(workflow_name)
+    write_wfm_config(config)
+
+
+def create_skill_links(repo_name: str) -> list[str]:
+    """Create symlinks/junctions for skills from a repo.
+
+    Creates links: ~/.claude/skills/{repo_name}-{skill} -> ~/.claude/repos/{repo_name}/skills/{skill}
+
+    Args:
+        repo_name: Name of the repo (e.g., "cicd")
+
+    Returns:
+        List of created skill link names
+    """
+    from wfm import platform as plat
+
+    repos_path = get_repos_path()
+    repo_path = repos_path / repo_name
+    repo_skills_path = repo_path / "skills"
+    global_skills_path = get_global_skills_path()
+
+    created = []
+
+    if not repo_skills_path.exists():
+        return created
+
+    # Ensure global skills directory exists
+    global_skills_path.mkdir(parents=True, exist_ok=True)
+
+    # Create links for each skill in the repo
+    for skill_dir in repo_skills_path.iterdir():
+        if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+            # Use directory name as-is, prefixed with repo name
+            link_name = f"{repo_name}-{skill_dir.name}"
+            link_path = global_skills_path / link_name
+
+            try:
+                plat.create_link(skill_dir, link_path)
+                created.append(link_name)
+            except Exception as e:
+                print(f"Warning: Failed to create link for {link_name}: {e}")
+
+    return created
+
+
+def create_workflow_links(repo_name: str) -> list[str]:
+    """Create symlinks/junctions for workflows from a repo.
+
+    Creates links: ~/.claude/workflows/{repo_name}-{workflow} -> ~/.claude/repos/{repo_name}/workflows/{workflow}
+
+    Args:
+        repo_name: Name of the repo (e.g., "cicd")
+
+    Returns:
+        List of created workflow link names
+    """
+    from wfm import platform as plat
+
+    repos_path = get_repos_path()
+    repo_path = repos_path / repo_name
+    repo_workflows_path = repo_path / "workflows"
+    global_workflows_path = get_global_workflows_path()
+
+    created = []
+
+    if not repo_workflows_path.exists():
+        return created
+
+    # Ensure global workflows directory exists
+    global_workflows_path.mkdir(parents=True, exist_ok=True)
+
+    # Create links for each workflow in the repo
+    for wf_dir in repo_workflows_path.iterdir():
+        if wf_dir.is_dir() and (wf_dir / "workflow.md").exists():
+            # Create link name with repo prefix
+            link_name = f"{repo_name}-{wf_dir.name}"
+            link_path = global_workflows_path / link_name
+
+            try:
+                plat.create_link(wf_dir, link_path)
+                created.append(link_name)
+            except Exception as e:
+                print(f"Warning: Failed to create link for {link_name}: {e}")
+
+    return created
+
+
+def remove_repo_links(repo_name: str) -> dict:
+    """Remove all symlinks/junctions for a repo.
+
+    Args:
+        repo_name: Name of the repo (e.g., "cicd")
+
+    Returns:
+        Dict with removed skills and workflows counts
+    """
+    from wfm import platform as plat
+
+    skills_path = get_global_skills_path()
+    workflows_path = get_global_workflows_path()
+
+    removed_skills = []
+    removed_workflows = []
+
+    # Remove skill links
+    if skills_path.exists():
+        for item in skills_path.iterdir():
+            if item.name.startswith(f"{repo_name}-") and plat.is_link(item):
+                try:
+                    plat.remove_link(item)
+                    removed_skills.append(item.name)
+                except Exception:
+                    pass
+
+    # Remove workflow links
+    if workflows_path.exists():
+        for item in workflows_path.iterdir():
+            if item.name.startswith(f"{repo_name}-") and plat.is_link(item):
+                try:
+                    plat.remove_link(item)
+                    removed_workflows.append(item.name)
+                except Exception:
+                    pass
+
+    return {
+        "removed_skills": removed_skills,
+        "removed_workflows": removed_workflows
+    }
+
+
+def detect_orphan_skills() -> list[str]:
+    """Detect skills that are directories (not symlinks/junctions).
+
+    These are skills created locally (e.g., via builder) that aren't linked to a repo.
+
+    Returns:
+        List of orphan skill names
+    """
+    from wfm import platform as plat
+
+    skills_path = get_global_skills_path()
+    orphans = []
+
+    if not skills_path.exists():
+        return orphans
+
+    ignored = get_ignored_skills()
+
+    for item in skills_path.iterdir():
+        if item.is_dir() and (item / "SKILL.md").exists():
+            # Skip if it's a link (managed by wfm)
+            if plat.is_link(item):
+                continue
+            # Skip if ignored
+            if item.name in ignored:
+                continue
+            orphans.append(item.name)
+
+    return orphans
+
+
+def detect_orphan_workflows() -> list[str]:
+    """Detect workflows that are directories (not symlinks/junctions).
+
+    Returns:
+        List of orphan workflow names
+    """
+    from wfm import platform as plat
+
+    workflows_path = get_global_workflows_path()
+    orphans = []
+
+    if not workflows_path.exists():
+        return orphans
+
+    ignored = get_ignored_workflows()
+
+    for item in workflows_path.iterdir():
+        if item.is_dir() and (item / "workflow.md").exists():
+            # Skip if it's a link (managed by wfm)
+            if plat.is_link(item):
+                continue
+            # Skip if ignored
+            if item.name in ignored:
+                continue
+            orphans.append(item.name)
+
+    return orphans
+
+
+def adopt_skill(skill_name: str, repo_name: str) -> dict:
+    """Move an orphan skill to a repo and create a symlink back.
+
+    Args:
+        skill_name: Name of the skill to adopt
+        repo_name: Name of the repo to adopt into
+
+    Returns:
+        Result dict with status
+    """
+    from wfm import platform as plat
+
+    skills_path = get_global_skills_path()
+    repos_path = get_repos_path()
+
+    skill_path = skills_path / skill_name
+    repo_path = repos_path / repo_name
+    repo_skills_path = repo_path / "skills"
+
+    # Validate
+    if not skill_path.exists():
+        return {"status": "error", "message": f"Skill '{skill_name}' not found"}
+
+    if plat.is_link(skill_path):
+        return {"status": "error", "message": f"Skill '{skill_name}' is already a link"}
+
+    if not repo_path.exists():
+        return {"status": "error", "message": f"Repository '{repo_name}' not found"}
+
+    target_skill_path = repo_skills_path / skill_name
+
+    # Move skill to repo
+    repo_skills_path.mkdir(parents=True, exist_ok=True)
+
+    if target_skill_path.exists():
+        return {"status": "error", "message": f"Skill '{skill_name}' already exists in repo '{repo_name}'"}
+
+    shutil.move(str(skill_path), str(target_skill_path))
+
+    # Create link back with repo prefix
+    link_name = f"{repo_name}-{skill_name}"
+    link_path = skills_path / link_name
+
+    try:
+        plat.create_link(target_skill_path, link_path)
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to create link: {e}"}
+
+    return {
+        "status": "success",
+        "message": f"Adopted '{skill_name}' into '{repo_name}' as '{link_name}'",
+        "original_name": skill_name,
+        "new_name": link_name,
+        "repo_path": str(target_skill_path)
+    }
+
+
+def adopt_workflow(workflow_name: str, repo_name: str) -> dict:
+    """Move an orphan workflow to a repo and create a symlink back.
+
+    Args:
+        workflow_name: Name of the workflow to adopt
+        repo_name: Name of the repo to adopt into
+
+    Returns:
+        Result dict with status
+    """
+    from wfm import platform as plat
+
+    workflows_path = get_global_workflows_path()
+    repos_path = get_repos_path()
+
+    workflow_path = workflows_path / workflow_name
+    repo_path = repos_path / repo_name
+    repo_workflows_path = repo_path / "workflows"
+
+    # Validate
+    if not workflow_path.exists():
+        return {"status": "error", "message": f"Workflow '{workflow_name}' not found"}
+
+    if plat.is_link(workflow_path):
+        return {"status": "error", "message": f"Workflow '{workflow_name}' is already a link"}
+
+    if not repo_path.exists():
+        return {"status": "error", "message": f"Repository '{repo_name}' not found"}
+
+    target_workflow_path = repo_workflows_path / workflow_name
+
+    # Move workflow to repo
+    repo_workflows_path.mkdir(parents=True, exist_ok=True)
+
+    if target_workflow_path.exists():
+        return {"status": "error", "message": f"Workflow '{workflow_name}' already exists in repo '{repo_name}'"}
+
+    shutil.move(str(workflow_path), str(target_workflow_path))
+
+    # Create link back with repo prefix
+    link_name = f"{repo_name}-{workflow_name}"
+    link_path = workflows_path / link_name
+
+    try:
+        plat.create_link(target_workflow_path, link_path)
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to create link: {e}"}
+
+    return {
+        "status": "success",
+        "message": f"Adopted '{workflow_name}' into '{repo_name}' as '{link_name}'",
+        "original_name": workflow_name,
+        "new_name": link_name,
+        "repo_path": str(target_workflow_path)
+    }


### PR DESCRIPTION
## Summary
- Replace download-and-copy architecture with git clone + symlinks/junctions (Windows junctions, Unix symlinks)
- Users manage git themselves (pull, push, commit), wfm manages the symlinks
- Add orphan detection: skills/workflows not linked to any repo are flagged during `wfm sync`

## Changes
- **New `wfm/platform.py`**: Cross-platform `create_link`, `remove_link`, `is_link` (junctions on Windows, symlinks on Unix)
- **`wfm/workflow_manager.py`**: `clone_repo`, `create_skill_links`, `create_workflow_links`, `detect_orphan_skills`, `adopt_skill`, `ignore_skill`, rewritten `sync_repo`/`sync_all`/`remove_repo`
- **`wfm/cli.py`**: Simplified CLI - removed `init`/`update`/`migrate`/`monitor`, added `repo pull`

## New commands
```
wfm repo add <name> <repo>   # Add, clone, create symlinks
wfm repo remove <name>       # Remove symlinks + cloned repo
wfm repo pull                # Git pull all repos
wfm sync                     # Recreate all symlinks, detect orphans
```

## Test plan
- [x] `wfm repo add` clones repo and creates junctions
- [x] `wfm repo remove` removes junctions and cloned folder
- [x] `wfm repo list` / `wfm list` / `wfm status` display correctly
- [x] `wfm repo pull` pulls all repos
- [x] `wfm sync` recreates links and detects orphans
- [x] Junctions verified on Windows (FILE_ATTRIBUTE_REPARSE_POINT)
- [x] Tested with dgx80/test-project-A and dgx80/test-project-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)